### PR TITLE
Reduces memory usage & CPU processing, fix for empty collection return

### DIFF
--- a/src/Messenger.php
+++ b/src/Messenger.php
@@ -131,10 +131,11 @@ class Messenger
                             ->where('deleted_from_receiver', 0);
                     });
                 })
+                ->latest()
                 ->take($take)
                 ->get();
 
-            return $messages;
+            return $messages->reverse();
         }
 
         return collect();

--- a/src/Messenger.php
+++ b/src/Messenger.php
@@ -121,7 +121,7 @@ class Messenger
         $conversation = $this->getConversation($authId, $withId);
 
         if ($conversation) {
-            $collection   = Message::whereConversationId($conversation->id)
+            $messages = Message::whereConversationId($conversation->id)
                 ->where(function ($query) use ($authId, $withId) {
                     $query->where(function ($qr) use ($authId) {
                         $qr->where('sender_id', $authId) // this message is sent by the authUser.
@@ -130,10 +130,8 @@ class Messenger
                         $qr->where('sender_id', $withId) // this message is sent by the receiver/withUser.
                             ->where('deleted_from_receiver', 0);
                     });
-                });
-            $totalRecords = $collection->count();
-            $messages     = $collection->take($take)
-                ->skip($totalRecords - $take)
+                })
+                ->take($take)
                 ->get();
 
             return $messages;

--- a/src/Messenger.php
+++ b/src/Messenger.php
@@ -137,7 +137,7 @@ class Messenger
             return $messages;
         }
 
-        return null;
+        return collect();
     }
 
     /**


### PR DESCRIPTION
**On "messagesWith()":**

Isn't necessary to load entire messages into collection.
Instead doing that, you can retrieve messages by latest & then take what you need (DB level), then reverse the collection to return to the view.

Also added a simple fix to return an empty collection in case that no conversation found between two users.